### PR TITLE
hotfix(cwal.yml): omit flags in smoke test

### DIFF
--- a/.github/workflows/cwa.yaml
+++ b/.github/workflows/cwa.yaml
@@ -45,5 +45,4 @@ jobs:
 
       - name: Smoke test
         run: |
-          python smoke_test.py sample.cwa.gz \
-            --lowpass_hz 20 --calibrate_gravity --detect_nonwear --resample_hz 50
+          python smoke_test.py sample.cwa.gz


### PR DESCRIPTION
Omit flags in smoke test as it hits Github Actions limits. Revert later when performance issues are fixed.