### PR TITLE
fix actigraph parsing

### DIFF
--- a/src/actipy/ActigraphReader.java
+++ b/src/actipy/ActigraphReader.java
@@ -437,7 +437,6 @@ public class ActigraphReader {
                     double y = twoSamples[4-twoSampleCounter*3];
                     double z = twoSamples[5-twoSampleCounter*3];
                     // double temp = 1.0d; // don't know temp yet
-                    t = getTrueUnixTime(t, infoTimeShift);
 
                     try {
                         writer.write(toItems(TimeUnit.MILLISECONDS.toNanos(t), x, y, z));
@@ -512,13 +511,13 @@ public class ActigraphReader {
                 // logger.log(Level.FINER, "x y z: " + sample[1] + " " + sample[0] + " " + sample[2]);
 
                 // double temp = 1.0d; // don't know temp yet
-                samples += 1;
                 long myTime = Math.round((1000d*samples)/sampleRate) + firstSampleTime*1000; // in Miliseconds
-                myTime = getTrueUnixTime(myTime, infoTimeShift);
+                samples += 1;
+
 
                 // Yes, sample[1] and sample[0] are swapped. Not the case elsewhere.
                 try {
-                    writer.write(toItems(myTime, sample[1], sample[0], sample[2]));
+                    writer.write(toItems(TimeUnit.MILLISECONDS.toNanos(myTime), sample[1], sample[0], sample[2]));
                 } catch (Exception e) {
                     System.err.println("Line write error: " + e.toString());
                 }
@@ -586,16 +585,14 @@ public class ActigraphReader {
                 }
 
                 // double temp = 1.0d; // don't know temp yet
-                samples += 1;
-
                 long myTime = Math.round((1000d*samples)/sampleRate) + firstSampleTime*1000; // in Miliseconds
-                myTime = getTrueUnixTime(myTime, infoTimeShift);
+                samples += 1;
 
                 // logger.log(Level.FINER, "i: " + i + "\nx y z: " + sample[0] + " " + sample[1] + " " + sample[2] +
                 //         "\nTime:" + myTime);
 
                 try {
-                    writer.write(toItems(myTime, sample[0], sample[1], sample[2]));
+                    writer.write(toItems(TimeUnit.MILLISECONDS.toNanos(myTime), sample[0], sample[1], sample[2]));
                 } catch (Exception e) {
                     System.err.println("Line write error: " + e.toString());
                 }


### PR DESCRIPTION
## Issue 

GT3X files parsing currently fail due to transition from BBA to actipy. 

This issue was likely caused by the Java to numpy datatype conversion interface resulting in a change in numeric precision from Milliseconds to Nanoseconds. I could be wrong about this. 
1. BBA: 

https://github.com/OxWearables/biobankAccelerometerAnalysis/blob/ca66bc7d6ae7356a424b147ab4905363fa6d2960/src/accelerometer/java/NpyWriter.java#L175

2. Actipy: 
https://github.com/OxWearables/actipy/blob/820606be373b70259ca2e00da605910cdce33dbd/src/actipy/NpyWriter.java#L323

## Fixes include 
- Change the timestamp unit 
- Correct the indexing issue for the first timestamp

## Testplan 
Verify that the current output is consistent with the `read.gt3x` parser in R

`actipy` output: 

![Screenshot 2024-04-12 at 00 34 05](https://github.com/OxWearables/actipy/assets/7655454/a7ba7092-4459-4638-9fcd-7b08b759d65e)


`read.gtx` output:

![Screenshot 2024-04-12 at 00 34 13](https://github.com/OxWearables/actipy/assets/7655454/f9ffffed-d209-48da-9f8a-a83459097715)
