### PR TITLE
Extract accelerometer and gyroscope cols from Ax6 cwa file

### DIFF
--- a/src/actipy/GENEActivReader.java
+++ b/src/actipy/GENEActivReader.java
@@ -218,17 +218,17 @@ public class GENEActivReader {
         }
         // read axes calibration lines for gain and offset values
         // data like -> x gain:25548 \n x offset:574 ... Volts:300 \n Lux:800
-        gainVals[0] = Double.parseDouble(readLine(reader).split(":")[1]); // xGain
-        offsetVals[0] = Integer.parseInt(readLine(reader).split(":")[1]); // xOffset
-        gainVals[1] = Double.parseDouble(readLine(reader).split(":")[1]); // y
-        offsetVals[1] = Integer.parseInt(readLine(reader).split(":")[1]); // y
-        gainVals[2] = Double.parseDouble(readLine(reader).split(":")[1]); // z
-        offsetVals[2] = Integer.parseInt(readLine(reader).split(":")[1]); // z
-        int volts = Integer.parseInt(readLine(reader).split(":")[1]); // volts
-        int lux = Integer.parseInt(readLine(reader).split(":")[1]); // lux
+        gainVals[0] = Double.parseDouble(readLine(reader).split(":")[1].trim()); // xGain
+        offsetVals[0] = Integer.parseInt(readLine(reader).split(":")[1].trim()); // xOffset
+        gainVals[1] = Double.parseDouble(readLine(reader).split(":")[1].trim()); // y
+        offsetVals[1] = Integer.parseInt(readLine(reader).split(":")[1].trim()); // y
+        gainVals[2] = Double.parseDouble(readLine(reader).split(":")[1].trim()); // z
+        offsetVals[2] = Integer.parseInt(readLine(reader).split(":")[1].trim()); // z
+        int volts = Integer.parseInt(readLine(reader).split(":")[1].trim()); // volts
+        int lux = Integer.parseInt(readLine(reader).split(":")[1].trim()); // lux
         readLine(reader); // 9 blank
         readLine(reader); // 10 memory status header
-        int numBlocksTotal = Integer.parseInt(readLine(reader).split(":")[1]); // 11
+        int numBlocksTotal = Integer.parseInt(readLine(reader).split(":")[1].trim()); // 11
 
         // ignore remaining header lines in bin file
         for (int i = 0; i < fileHeaderSize - linesToAxesCalibration - 11; i++) {

--- a/src/actipy/processing.py
+++ b/src/actipy/processing.py
@@ -375,7 +375,7 @@ def calibrate_gravity(data, calib_cube=0.3, calib_min_samples=50, window='10s', 
 
     info['CalibErrorAfter(mg)'] = best_err * 1000
 
-    if (best_err > ERR_TOL) or (it + 1 == MAXITER):
+    if (best_err >= ERR_TOL) or (it + 1 >= MAXITER):
         info['CalibOK'] = 0
 
         return data, info

--- a/src/actipy/processing.py
+++ b/src/actipy/processing.py
@@ -315,9 +315,15 @@ def calibrate_gravity(data, calib_cube=0.3, calib_min_samples=50, window='10s', 
 
     # Check that we have sufficiently uniformly distributed points:
     # need at least one point outside each face of the cube
-    if (np.max(xyz, axis=0) < calib_cube).any() \
-            or (np.min(xyz, axis=0) > -calib_cube).any():
+    if (np.max(xyz, axis=0) < calib_cube).any() or (np.min(xyz, axis=0) > -calib_cube).any():
         info['CalibOK'] = 0
+        info['CalibErrorAfter(mg)'] = init_err * 1000
+
+        return data, info
+
+    # If initial error is already below threshold, skip and return
+    if init_err < ERR_TOL:
+        info['CalibOK'] = 1
         info['CalibErrorAfter(mg)'] = init_err * 1000
 
         return data, info

--- a/src/actipy/reader.py
+++ b/src/actipy/reader.py
@@ -61,6 +61,10 @@ def read_device(input_file,
 
     sample_rate = info['SampleRate']
 
+    if len(data) == 0:
+        print("File is empty. No data to process.")
+        return data, info
+
     if lowpass_hz not in (None, False):
         timer.start("Lowpass filter...")
         data, info_lowpass = P.lowpass(data, sample_rate, lowpass_hz)
@@ -197,6 +201,16 @@ def _read_device(input_file, verbose=True):
         data_mmap = np.load(os.path.join(tmpdir, "data.npy"), mmap_mode='r')
         data = {c: np.asarray(data_mmap[c]) for c in data_mmap.dtype.names}
         data = pd.DataFrame(data, copy=False)
+
+        if len(data) == 0:
+            info['NumTicks'] = 0
+            info['StartTime'] = None
+            info['EndTime'] = None
+            info['WearTime(days)'] = 0
+            info['NumInterrupts'] = 0
+            data.set_index('time', inplace=True)
+            timer.stop()
+            return data, info
 
         # Check for non-increasing timestamps. This is rare but can happen with
         # buggy devices. TODO: Parser should do this.


### PR DESCRIPTION
This PR addresses #37 allowing for the parsing of AX6 device.

To do so, we follow changes made at https://github.com/digitalinteraction/openmovement/commit/570001c28c7fec3d5aba904b3712e0cb9b12ef6c to address parsing of the AX6 device.

To test this is working as expected, we have 4 files:
1. A raw sample cwa captured from an Ax3 device
2. A raw csv file extracted from OmGUI for the cwa file in Part 1
3. A raw sample cwa captured from an Ax6 device
4. A raw csv file extracted from OmGUI for the cwa file in Part 3

We have tested to ensure:
1. actipy.read_device(file1) continues to work as expected
2. actipy.read_device(file1) produces acc values similar to file2
3. actipy.read_device(file3) works, while adding new gyroscope columns
4. actipy.read_device(file3) produces acc and gyro values similar to file4

Test system configuration:
![image](https://github.com/user-attachments/assets/f757e0ee-5071-4b7e-8f53-10ee0c7272bf)

Test1:  
![image](https://github.com/user-attachments/assets/98757df0-6640-4b0c-a61e-109ae5bb8382)

Test2:
![image](https://github.com/user-attachments/assets/6e2f3349-f468-4436-8ab8-03d89e5b46a9)

Test3:
![image](https://github.com/user-attachments/assets/5b028fdb-dac8-4597-8548-7b13b813025c)

Test4:
![image](https://github.com/user-attachments/assets/dd0fd4a2-f001-4659-b70a-42a669c7e8c6)
 
*Note*: An error is reported stating the "data.npy file cannot access the file because it is being used by another process." however this error is not related to this work, and file reading works despite the error. I have therefore reported it in a New issue #41