### PR TITLE
Add wear coverage to output properties of info.json file

### DIFF
--- a/src/actipy/reader.py
+++ b/src/actipy/reader.py
@@ -91,6 +91,9 @@ def read_device(input_file,
             data, info_resample = P.resample(data, resample_hz)
         info.update(info_resample)
         timer.stop()
+        
+    info_wear_coverage = calculate_wear_coverage(data)
+    info.update(info_wear_coverage)
 
     return data, info
 
@@ -403,6 +406,19 @@ def fix_nonincr_time(data):
                     .fillna(pd.Timedelta(1))
                     > pd.Timedelta(0)]
     return data, errs
+
+
+def calculate_wear_coverage(data):
+    """ Check device wear covers all 24 hours of the day """
+    info = {}
+    coverage = data.groupby(data.index.hour).agg(lambda x: x.notna().mean())
+    
+    if len(coverage) < 24 or np.min(coverage) < 0.01:
+        info['Covers24hOK'] = 0
+    else:
+        info['Covers24hOK'] = 1
+    
+    return info
 
 
 class Timer:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -25,7 +25,8 @@ def test_read_device():
         "EndTime": '2023-06-08 15:19:33',
         "NumTicks": 1021800,
         "WearTime(days)": 0.1211432638888889,
-        "NumInterrupts": 1
+        "NumInterrupts": 1,
+        "Covers24hOK": 0
     }
     assert_dict_equal(info, info_ref, rel=0.01)
 


### PR DESCRIPTION
When running actipy (and other packages that use actipy such as actinet), it is useful to know whether the device wear has 24 hour coverage.

This means that over the full period of wear, each hour of the day contains accelerometer data exceeding the threshold for detecting device wear. 

This follows changes made in: https://github.com/OxWearables/stepcount/pull/95/files
This addresses part of #36 