### PR TITLE
feat: split detect_nonwear: find_nonwear_segments and flag_nonwear

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -53,7 +53,7 @@ def main():
     if args.detect_nonwear:
         timer.start('Detecting nonwear...')
         with memray.Tracker(f'{memray_dir}/detect_nonwear.bin'):
-            data, info_nonwear = P.detect_nonwear(data, patience='1m')
+            data, info_nonwear = P.flag_nonwear(data, patience='1m')
         timer.stop()
         info.update(info_nonwear)
 

--- a/src/actipy/reader.py
+++ b/src/actipy/reader.py
@@ -110,7 +110,7 @@ def read_device(input_file,
 
     if detect_nonwear:
         timer.start("Nonwear detection...")
-        data, info_nonwear = P.detect_nonwear(data)
+        data, info_nonwear = P.flag_nonwear(data)
         info.update(info_nonwear)
         timer.stop()
 
@@ -176,7 +176,7 @@ def process(data, sample_rate,
 
     if detect_nonwear:
         timer.start("Nonwear detection...")
-        data, info_nonwear = P.detect_nonwear(data)
+        data, info_nonwear = P.flag_nonwear(data)
         info.update(info_nonwear)
         timer.stop()
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -101,7 +101,7 @@ def test_detect_nonwear():
 
     data, info = read_device()
     # Use a bad patience to force nonwear detection
-    data, info_nonwear = P.detect_nonwear(data, patience='1m')
+    data, info_nonwear = P.flag_nonwear(data, patience='1m')
 
     info_nonwear_ref = {
         'WearTime(days)': 0.1203330787037037,


### PR DESCRIPTION
- Extract main nonwear finding logic to new function `detect_nonwear_segments` and rename existing function `detect_nonwear` to `flag_nonwear`.
- Both `detect_nonwear_segments` and `flag_nonwear` are made available via the processing module.

Closes https://github.com/OxWearables/actipy/issues/52