### PR TITLE
fix(processing): consider NA rows only for x, y, z columns when calculating time deltas

### DIFF
--- a/src/actipy/processing.py
+++ b/src/actipy/processing.py
@@ -75,7 +75,7 @@ def quality_control(data, sample_rate):
     info['EndTime'] = data.index[-1].strftime(time_format)
     info['NumTicks'] = len(data)
     tol = pd.Timedelta('1s')
-    tdiff = data.dropna().index.to_series().diff()  # Note: Index.diff() was only added in pandas 2.1
+    tdiff = data.dropna(subset=['x', 'y', 'z']).index.to_series().diff()  # Note: Index.diff() was only added in pandas 2.1
     total_time = tdiff[tdiff < tol].sum().total_seconds()
     num_interrupts = (tdiff > tol).sum()
     del tdiff  # we're done with this


### PR DESCRIPTION
This pull request improves the data quality control logic in `src/actipy/processing.py` by checking only the acceleration columns (`x`, `y`, and `z`) for missing values when calculating time deltas. This makes the check more lenient and avoids unnecessary filtering caused by sparse columns like `heart_rate` and `ambient_temperature`, especially relevant for the new Matrix device parser.